### PR TITLE
Adding ability to have a manifests cache

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -77,8 +77,9 @@ If you like, you can pass any of these options to the `start` or `precompile` fu
 * `servePath` (defaults to ''): The path you want to append to all asset URLs.  Useful for pointing at an external CDN location.
 * `builtAssets` (defaults to 'builtAssets'): The folder you want precompiled assets to be placed in.
 * `context` (defaults to global): The object you want to hang the 'css', 'js', and 'img' functions on for resolving static assets.
-* `gzip` (defaults to false): Whether or not to gzip the contents of 'css' and 'js' files.
+* `gzip` (defaults to `false`): Whether or not to gzip the contents of 'css' and 'js' files.
 * `scanDir` (defaults to ''): Include a base path you want asset-manager to scan for modules that contain `asset-manifest.json` files indicating the module contains static assets that should be available for use.
+* `cacheFile` (defaults to `null`): A full path to the location of a cache file for the `asset-manifest.json` files. If used, this stores the results in this file, so for any new changes, simply delete that file.
 
 # USAGE
 

--- a/lib/asset-manager.js
+++ b/lib/asset-manager.js
@@ -27,6 +27,7 @@ function init(config){
   config.gzip = !!config.gzip;
   config.assetFilter = config.assetFilter || function() {return true;};
   config.scanDir = config.scanDir || false;
+  config.cacheFile = config.cacheFile || false;
 }
 
 function start(config, cb) {
@@ -49,9 +50,8 @@ function start(config, cb) {
     if(cb) {
       cb();
     }
-  }
-  else {
-    utils.expandPaths(config.paths, config.scanDir, function(expandedPaths){
+  } else {
+    utils.expandPaths(config.paths, config.scanDir, config.cacheFile, function(expandedPaths){
       paths = expandedPaths;
       //Output the paths that will be checked when resolving assets
       debug("Asset Resolution Paths:");

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -206,7 +206,6 @@ exports.expandPaths = function expandPaths(origPaths, scanDir, cacheFile, cb){
 
 function detectFoldersWithManifest(scanDir, cacheFile, cb) {
   var checkPath = scanDir ? scanDir + "/**/asset-manifest.json" : false;
-  var cacheFile = cacheFile ? process.cwd() + "/" + cacheFile.replace(/^\./,"") : false;
 
   if (cacheFile) {
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,7 +162,7 @@ exports.findModuleCSSFiles = function(moduleFolders) {
  * Given a list of paths that may contain globs, resolve the globs and set the `paths` to be an array
  * of all the actual paths that `origPaths` expands to
  */
-exports.expandPaths = function expandPaths(origPaths, scanDir, cb){
+exports.expandPaths = function expandPaths(origPaths, scanDir, cacheFile, cb){
   //Take a path that contains a potential glob in it and resolve it to the list of files corresponding to that glob
   var expandPath = function expandPath(aPath, cb){
     if(aPath.indexOf("*") === -1) {
@@ -184,7 +184,7 @@ exports.expandPaths = function expandPaths(origPaths, scanDir, cb){
     }
   };
 
-  detectFoldersWithManifest(scanDir, function(manifestPaths) {
+  detectFoldersWithManifest(scanDir, cacheFile, function(manifestPaths) {
     origPaths = origPaths.concat(manifestPaths);
 
     async.map(origPaths, expandPath, function expandPathsComplete(er, results){
@@ -204,41 +204,61 @@ exports.expandPaths = function expandPaths(origPaths, scanDir, cb){
   });
 };
 
-function detectFoldersWithManifest(scanDir, cb) {
+function detectFoldersWithManifest(scanDir, cacheFile, cb) {
   var checkPath = scanDir ? scanDir + "/**/asset-manifest.json" : false;
+  var cacheFile = cacheFile ? process.cwd() + "/" + cacheFile.replace(/^\./,"") : false;
+
+  if (cacheFile) {
+    try {
+      var cache = require(cacheFile);
+      console.info('Loading asset-manifests from cache: ' + cacheFile);
+      return globCB(null, cache, true);
+    } catch (e) {
+      console.info('Generating asset-manifest cache');
+    }
+  }
 
   if(scanDir) {
     glob(checkPath, {
       mark: true,
       strict: true
-    }, function globCB(er, files){
-      if(!files || files.length === 0) {
-        return cb([]);
-      }
-
-      var finalFolders = files.map(function(file) {
-        var manifestFile = fs.readFileSync(file, 'utf8'),
-            manifest = null;
-
-        try {
-          if(file.indexOf("asset-manager") !== -1) {
-            return ''
-          }
-          manifest = JSON.parse(manifestFile);
-          if(manifest.assetPath) {
-            return path.join(path.dirname(file), manifest.assetPath);
-          } else {
-            console.warn("Missing assetPath property in the manifest file: " + file);
-          }
-        } catch(e) {
-          console.error("Unable to parse manifest file '" + file + "':" + e.message);
-        }
-        return '';
-      });
-      cb(finalFolders);;
-    });
+    }, globCB);
   } else {
     cb([]);
+  }
+
+  function globCB(err, files, cached) {
+    if(!files || files.length === 0) {
+      return cb([]);
+    }
+
+    if (cacheFile && ! cached) {
+      fs.writeFile(cacheFile, JSON.stringify(files, null, 2), function(err) {
+        if (err) console.error(err);
+        console.log('Manifest files cached: ' + cacheFile);
+      });
+    }
+
+    var finalFolders = files.map(function(file) {
+      var manifestFile = fs.readFileSync(file, 'utf8'),
+          manifest = null;
+
+      try {
+        if(file.indexOf("asset-manager") !== -1) {
+          return ''
+        }
+        manifest = JSON.parse(manifestFile);
+        if(manifest.assetPath) {
+          return path.join(path.dirname(file), manifest.assetPath);
+        } else {
+          console.warn("Missing assetPath property in the manifest file: " + file);
+        }
+      } catch(e) {
+        console.error("Unable to parse manifest file '" + file + "':" + e.message);
+      }
+      return '';
+    });
+    cb(finalFolders);;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asset-manager",
   "description": "Asset manager built on top of connect-asset for managing multiple asset folders.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "FamilySearch Web Developers",
   "repository": {
     "type": "git",

--- a/test/no_search/asset-manifest.json
+++ b/test/no_search/asset-manifest.json
@@ -1,0 +1,3 @@
+{
+  "assetPath": "assets"
+}

--- a/test/no_search/assets/css/module.css
+++ b/test/no_search/assets/css/module.css
@@ -1,0 +1,1 @@
+body {display:none}

--- a/test/test_modules/cache.json
+++ b/test/test_modules/cache.json
@@ -1,0 +1,3 @@
+[
+  "test/no_search/asset-manifest.json"
+]

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -245,7 +245,7 @@ describe("Utils tests", function(){
 
     it("expand with cacheFile path", function(done) {
       var basePaths = ['test/app1'];
-      this.utils.expandPaths(basePaths, "test/test_modules", "test/test_modules/cache.json", function(paths) {
+      this.utils.expandPaths(basePaths, "test/test_modules", process.cwd() + "/test/test_modules/cache.json", function(paths) {
         assert.equal(paths.length, 2);
         assert.notEqual(paths.indexOf("test/app1"), -1);
         assert.notEqual(paths.indexOf("test/no_search/assets"), -1);

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -191,7 +191,7 @@ describe("Utils tests", function(){
   describe("Test expandPaths", function(){
     it("expand a single path", function(done){
       var basePaths = ['test/app1'];
-      this.utils.expandPaths(basePaths, false, function(paths) {
+      this.utils.expandPaths(basePaths, false, null, function(paths) {
         assert.equal(paths.length, 1);
         assert.equal(paths[0], "test/app1");
         done();
@@ -212,7 +212,7 @@ describe("Utils tests", function(){
 
     it("expand multiple paths", function(done){
       var basePaths = ['test/app1', 'test/app2'];
-      this.utils.expandPaths(basePaths, false, function(paths) {
+      this.utils.expandPaths(basePaths, false, null, function(paths) {
         assert.equal(paths.length, 2);
         assert.notEqual(paths.indexOf("test/app1"), -1);
         assert.notEqual(paths.indexOf("test/app2"), -1);
@@ -222,7 +222,7 @@ describe("Utils tests", function(){
 
     it("expand wildcard path", function(done){
       var basePaths = ['test/app*'];
-      this.utils.expandPaths(basePaths, false, function(paths) {
+      this.utils.expandPaths(basePaths, false, null, function(paths) {
         assert.equal(paths.length, 5);
         assert.notEqual(paths.indexOf("test/app1"), -1);
         assert.notEqual(paths.indexOf("test/app2"), -1);
@@ -235,7 +235,7 @@ describe("Utils tests", function(){
 
     it("expand with scanDir path", function(done){
       var basePaths = ['test/app1'];
-      this.utils.expandPaths(basePaths, "test/test_modules", function(paths) {
+      this.utils.expandPaths(basePaths, "test/test_modules", null, function(paths) {
         assert.equal(paths.length, 2);
         assert.notEqual(paths.indexOf("test/app1"), -1);
         assert.notEqual(paths.indexOf("test/test_modules/moduleWithControls/assets"), -1);
@@ -243,9 +243,19 @@ describe("Utils tests", function(){
       });
     });
 
+    it("expand with cacheFile path", function(done) {
+      var basePaths = ['test/app1'];
+      this.utils.expandPaths(basePaths, "test/test_modules", "test/test_modules/cache.json", function(paths) {
+        assert.equal(paths.length, 2);
+        assert.notEqual(paths.indexOf("test/app1"), -1);
+        assert.notEqual(paths.indexOf("test/no_search/assets"), -1);
+        done();
+      });
+    });
+
     it("expand invalid path", function(done){
       var basePaths = ['noPath/here'];
-      this.utils.expandPaths(basePaths, false, function(paths) {
+      this.utils.expandPaths(basePaths, false, null, function(paths) {
         assert.equal(paths.length, 0);
         done();
       });


### PR DESCRIPTION
By using a manifests cache, we can prevent the startup time from having to perform another Glob every time. This saves 5-6 seconds on EVERY startup. To clear the cache, simply remove the cache file.

@intervalia / @redbugz, any thoughts?