### PR TITLE
Pushes the lang and template variables to the top of the assembly so tha...

### DIFF
--- a/lib/contentResolver.js
+++ b/lib/contentResolver.js
@@ -157,9 +157,6 @@ function readContentSync(meta, isSubAssembly) {
           contents += assembly.prefix + '\n\n';
         }
 
-        // Append any files
-        contents += appendFiles(meta.baseModulePath, filesLength, assembly.files);
-
         if(hasTranslations) {
           // Append any locale strings
           contents += appendLocaleStrings(baseLocalePath, localeFileName);
@@ -172,6 +169,9 @@ function readContentSync(meta, isSubAssembly) {
           // Append the html template files found in the templates folder
           contents += appendTemplateFiles(baseTemplatePath, templatePath, hasTranslations);
         }
+
+        // Append any files
+        contents += appendFiles(meta.baseModulePath, filesLength, assembly.files);
 
         if(assembly.simpleWrap) {
           contents += "}(window));";


### PR DESCRIPTION
...t they are always accessible in your files. Currently if you use vanilla JS in your assembly and want to access the lang or template variables, you have to wrap your code in a setTimeout so that it will skip execution of your code and execute the lang and template code before yours.