### PR TITLE
Updating Stylus pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "uglify-js": "1.2.x",
     "less": "1.3.x",
     "coffee-script": "1.4.x",
-    "stylus": "0.42.3",
+    "stylus": "0.50.0",
     "debug": "~0.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
 Our current version does not support variables inside `@media` tags (http://learnboost.github.io/stylus/docs/media.html#interpolations-and-variables).