### PR TITLE
Fix for correctly escaping the " \ " character when converting an HTML template into a string.

### DIFF
--- a/lib/contentResolver.js
+++ b/lib/contentResolver.js
@@ -353,7 +353,7 @@ function getTemplateAsString(fileName) {
 
 function flattenHtml(html) {
   html = html.replace(/(\r*\n)+/g, "\n");
-  html = html.replace(/\\/, "\\\\").replace(/"/g, "\\\"");
+  html = html.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
   var lines = html.split("\n");
   var text = "";
 

--- a/lib/contentResolver.js
+++ b/lib/contentResolver.js
@@ -353,7 +353,7 @@ function getTemplateAsString(fileName) {
 
 function flattenHtml(html) {
   html = html.replace(/(\r*\n)+/g, "\n");
-  html = html.replace(/"/g, "\\\"");
+  html = html.replace(/\\/, "\\\\").replace(/"/g, "\\\"");
   var lines = html.split("\n");
   var text = "";
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -378,7 +378,7 @@ exports.convertHTMLtoJS = function convertHTMLtoJS(html, hasLangResources){
  * @return The passed in html safely formated so that it can be used in a javascript assignment operator.
  */
 function flattenString(html) {
-  var escapedQuotes = html.replace(/"/g, "\\\""),
+  var escapedQuotes = html.replace(/\\/g, "\\\\").replace(/"/g, "\\\""),
   lines = escapedQuotes.split(BACKSLASH_N),
   sb = '',
   inExcludeBlock = false;
@@ -393,7 +393,7 @@ function flattenString(html) {
       if (sb) {
         sb += "+\n";
       }
-      sb += "\"" + line.replace(/\\/, "\\\\") + "\\n\"";
+      sb += "\"" + line + "\\n\"";
     }
 
     if(line.indexOf("<!-- exclude END -->") !== -1) { //end block

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -393,7 +393,7 @@ function flattenString(html) {
       if (sb) {
         sb += "+\n";
       }
-      sb += "\"" + line + "\\n\"";
+      sb += "\"" + line.replace(/\\/, "\\") + "\\n\"";
     }
 
     if(line.indexOf("<!-- exclude END -->") !== -1) { //end block

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -378,10 +378,10 @@ exports.convertHTMLtoJS = function convertHTMLtoJS(html, hasLangResources){
  * @return The passed in html safely formated so that it can be used in a javascript assignment operator.
  */
 function flattenString(html) {
-  var escapedQuotes = html.replace(/\\/g, "\\\\").replace(/"/g, "\\\""),
-  lines = escapedQuotes.split(BACKSLASH_N),
-  sb = '',
-  inExcludeBlock = false;
+  var escapedQuotes = html.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+  var lines = escapedQuotes.split(BACKSLASH_N);
+  var sb = '';
+  var inExcludeBlock = false;
 
   for(var i=0; i<lines.length; ++i){
     var line = lines[i];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -393,7 +393,7 @@ function flattenString(html) {
       if (sb) {
         sb += "+\n";
       }
-      sb += "\"" + line.replace(/\\/, "\\") + "\\n\"";
+      sb += "\"" + line.replace(/\\/, "\\\\") + "\\n\"";
     }
 
     if(line.indexOf("<!-- exclude END -->") !== -1) { //end block

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -318,11 +318,11 @@ describe("Utils tests", function(){
     });
 
     it("convert body with tags and double quotes", function(){
-      var html = "<html><body><a href=\"hello\">MyText</a></body></html>";
+      var html = '<html><body><a href="hello">MyText</a></body></html>';
       var js = this.utils.convertHTMLtoJS(html);
 
       assert.equal(typeof(js), "string");
-      assert.equal(this.appendSnippetCode("var snippetsRaw = \"<a href=\\\"hello\\\">MyText</a>\\n\";"), js);
+      assert.equal(this.appendSnippetCode('var snippetsRaw = "<a href=\\"hello\\">MyText</a>\\n";'), js);
     });
 
     it("convert multiline body", function(){


### PR DESCRIPTION
I tried to add a pattern attribute to some new HTML and found that the HTML to string code did not correctly escape the \ character. This is now fixed.