### PR TITLE
Fixes problem with symlinked modules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -238,7 +238,8 @@ function detectFoldersWithManifest(scanDir, cb) {
   if(scanDir) {
     glob(checkPath, {
       mark: true,
-      strict: true
+      strict: true,
+      follow: true
     }, function globCB(er, files){
       if(!files || files.length === 0) {
         return cb([]);


### PR DESCRIPTION
If you npm link a dependency, and it has dependencies with asset-manifest.json files, they will not be found because glob won't traverse the symlinked directory. This was introduced in #78.
This fixes that problem, but slows down startup times. One of our larger projects startup time goes from 8 seconds to 20 seconds with this change.
